### PR TITLE
chore(ci): 依存・コードの脆弱性検知とテンプレート・concurrency を導入

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,82 @@
+name: バグ報告 / Bug report
+description: 動作不良・想定外の挙動の報告 / Report broken or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        日本語・英語どちらでも歓迎です。/ Reports are welcome in Japanese or English.
+
+        脆弱性の報告は公開 Issue ではなく inquiry@ta-yan.ai へメールでお願いします([SECURITY.md](https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/SECURITY.md) 参照)。
+        / For security vulnerabilities, please email inquiry@ta-yan.ai instead of opening a public issue.
+
+        > **.dmp ファイルの添付にご注意ください** — DUMP ファイルには業務データが含まれます。添付する場合は機密情報を含まない再現用の最小データにしてください。
+        > / **Be careful attaching .dmp files** — they contain your database contents. Attach only minimal, non-confidential reproduction data.
+  - type: input
+    id: version
+    attributes:
+      label: バージョン / Version
+      description: ヘルプ > バージョン情報、またはインストーラーのファイル名で確認できます / See Help > About, or the installer filename
+      placeholder: "4.1.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: 導入方法 / Install method
+      options:
+        - インストーラー版 EXE / Installer (EXE)
+        - ポータブル版 ZIP / Portable (ZIP)
+        - Microsoft Store
+        - winget
+        - ソースからビルド / Built from source
+    validations:
+      required: true
+  - type: dropdown
+    id: channel
+    attributes:
+      label: チャネル / Channel
+      options:
+        - 安定版 / Stable
+        - ベータ版 / Beta
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "Windows 11 24H2 x64 / Windows 11 ARM64 など"
+    validations:
+      required: true
+  - type: dropdown
+    id: dump-format
+    attributes:
+      label: DUMP 形式 / Dump format
+      description: 解析対象のファイル形式。不明な場合は「不明」で構いません / Leave as unknown if unsure
+      options:
+        - EXPDP (DataPump)
+        - EXP (レガシー / legacy)
+        - 該当しない・不明 / Not applicable or unknown
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: 再現手順 / Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: 期待した動作と実際の動作 / Expected vs actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: エラーメッセージ・スクリーンショット / Error messages & screenshots
+      description: エラーダイアログの全文や画面のスクリーンショットがあると調査が速くなります / Full error text and screenshots speed up investigation

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 脆弱性の報告 / Report a security vulnerability
+    url: https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/SECURITY.md
+    about: 脆弱性は公開 Issue ではなく inquiry@ta-yan.ai へメールでご報告ください / Please email inquiry@ta-yan.ai, not a public issue. See SECURITY.md
+  - name: ライセンス・購入に関するお問い合わせ / Licensing & purchase
+    url: https://www.odv.dev/
+    about: ライセンスの取得・プラン・お支払いに関するご相談は公式サイトへ / License plans and purchasing are handled on the official site

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,27 @@
+name: 機能要望 / Feature request
+description: 新機能・改善の提案 / Propose a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        日本語・英語どちらでも歓迎です。/ Proposals are welcome in Japanese or English.
+
+        本アプリの目的は「Oracle 環境なしで .dmp ファイルを解析・閲覧する」ことです。この範囲での提案をお願いします。
+        / The goal of this app is to analyze and browse .dmp files without an Oracle environment.
+  - type: textarea
+    id: problem
+    attributes:
+      label: 解決したい課題 / Problem to solve
+      description: どんな場面で何に困っているか(機能の形ではなく課題として書いていただけると、より良い解決策を検討できます) / Describe the problem rather than the solution
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案する解決策 / Proposed solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 検討した代替案 / Alternatives considered
+      description: 既存機能・他ツールでの回避策を試した場合はその結果も / Include workarounds you already tried

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- PR タイトルは Conventional Commits 形式で(squash 時の最終コミットメッセージになります) -->
+
+## 概要
+
+<!-- 何を・なぜ。関連 Issue があれば #番号 で参照 -->
+
+## チェックリスト
+
+該当しない行は削除してください。正本は [AGENTS.md](AGENTS.md)。
+
+- [ ] バージョンを上げた → **3ファイルすべて**を更新した(`Open DUMP Viewer.vbproj` の `<Version>` / `Logics/DumpParser/odv_api.c` の `ODV_VERSION_STRING` / `CHANGELOG.md`)
+- [ ] C ネイティブ DLL(`Logics/DumpParser`)を変更した → Windows(`_build.cmd`)でビルドし、実際の .dmp ファイルで解析を確認した
+- [ ] UI 文言を追加・変更した → `Strings.resx` と各言語版(en/zh/ko/de/fr/es/it/ru/pt-BR)を更新した
+- [ ] インストーラーの挙動に影響 → `installer/setup.iss` を更新した
+- [ ] 動作環境・機能の記述に影響 → `README.md` の該当箇所も更新した
+- [ ] 外部依存の追加・更新 → 当日ライブ検証の記録を下に残した
+
+<!-- 外部依存を追加・更新した場合のみ:
+Vendored: <pkg> <ver> (verified <cmd> = <ver>, YYYY-MM-DD)
+-->
+
+## 検証
+
+<!-- 何をどう確認したか。手元でのビルド・動作確認の結果を書いてください -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot 設定(依存の脆弱性対策の「継続監視」層)。
+#
+# 依存の脆弱性検知は三層で構成する:
+#   1. NuGet Audit — Open DUMP Viewer.vbproj の NuGetAuditMode=all + WarningsAsErrors(NU1900-1904)。
+#      restore/build のたびに照合し、脆弱な依存が入るとビルドを止める
+#   2. dependency-review-action(.github/workflows/dependency-review.yml)— PR 差分として
+#      入ってくる依存(GitHub Actions を含む)を審査する
+#   3. Dependabot(本ファイル + リポジトリ設定の脆弱性アラート / 自動セキュリティ更新)—
+#      マージ後・リリース後も継続監視し、脆弱性公表時に修正 PR を自動作成する
+#
+# C ネイティブ DLL(Logics/DumpParser)は外部ライブラリに依存しない自己完結の C11 実装のため
+# パッケージエコシステムの対象外。こちらの脆弱性は CodeQL の c-cpp 解析(codeql.yml)が担当する。
+#
+# AGENTS.md「バージョンポリシー」の「すべてのランタイム・SDK・ツールは常に最新バージョンを
+# 使用する」を機械化する役割も兼ねる(GitHub Actions の版追従を人手に依存させない)。
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    # 通常の版追従はまとめて 1 本の PR にする(minor / patch)。major は個別 PR。
+    # セキュリティ更新はグループ化の対象外で、常に個別 PR として即時作成される。
+    groups:
+      nuget-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-and-release-beta.yml
+++ b/.github/workflows/build-and-release-beta.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - beta
 
+# 同一ブランチのリリース実行が重ならないようにする。cancel-in-progress は **false**
+# (実行の途中で Pre-release 作成や Store 提出まで進むため、割り込みキャンセルはしない)。
+# 詳細は build-and-release.yml の同じブロックのコメントを参照。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ═══════════════════════════════════════════
   # ビルドジョブ (x64 / ARM64 並列)

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -18,6 +18,15 @@ on:
         type: boolean
         default: true
 
+# 同一ブランチのリリース実行が重ならないようにする(連続 push で 2 本のリリースが
+# 並走し、Release 作成や Store 提出が競合するのを防ぐ)。
+# cancel-in-progress は **false**。本ワークフローは実リリースを作成し Microsoft Store へ
+# 提出するため、途中でキャンセルすると中途半端な成果物や提出が残りうる。後続の実行は
+# 割り込まずに待たせる。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ═══════════════════════════════════════════
   # ビルドジョブ (x64 / ARM64 並列)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,84 @@
+# CodeQL 静的解析(C ネイティブ DLL + GitHub Actions ワークフロー)。結果は Security タブ
+# (code scanning alerts)に集約される。public リポジトリのため無償。
+#
+# ■ 解析対象と、対象外の明示
+#
+# CodeQL は VB.NET を解析できない(対応言語は C/C++・C#・GitHub Actions・Go・Java・Kotlin・
+# JavaScript・Python・Ruby・Rust・Swift・TypeScript。csharp 解析も .vb は対象にしない。
+# 検証日 2026-07-18、codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/)。
+# したがって HMI/ と Logics/ の VB.NET コードは本ワークフローの対象外である。
+#
+# 対象に含めるのは次の 2 つ:
+#   - c-cpp  : Logics/DumpParser の C11 実装。**信頼できない .dmp ファイルを直接パースする**
+#              最も攻撃面の大きい層であり、SECURITY.md が「対象となる脆弱性」の筆頭に挙げる
+#              「.dmp ファイル解析時のバッファオーバーフロー」がまさにここで起きる
+#   - actions: ワークフロー自身の脆弱性(script injection・過剰な権限など)
+#
+# VB.NET 側の穴埋めは NuGet Audit(vbproj の NuGetAuditMode=all)が依存の脆弱性を担当する。
+# 三層構成の全体像は .github/dependabot.yml 冒頭のコメントを参照。
+#
+# ■ ビルドモード
+#
+# c-cpp は build-mode: manual とし、Logics/DumpParser の POSIX 向け Makefile を gcc で
+# 実際にコンパイルして解析する。C/C++ は build-mode: none も選べるが、マクロ展開とヘッダ
+# 解決が不完全になり検出精度が落ちるため、実ビルドを通す方を採る(この Makefile は
+# 外部依存のない自己完結の C11 実装であり、ubuntu ランナー上で完結する)。
+#
+# ■ 週次 schedule
+#
+# 「コード側の変更がなくても、CodeQL のクエリ更新(新規に公表された脆弱性パターン)を
+# 既存コードへ適用する」ための定期実行。
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 20 * * 0' # 毎週月曜 05:30 JST(日曜 20:30 UTC)
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write # code scanning への結果アップロードに必要
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: manual
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # build-mode: manual の言語のみ。init と analyze の間で実ビルドを通す必要がある。
+      - name: Build native dump parser (c-cpp)
+        if: matrix.language == 'c-cpp'
+        run: make
+        working-directory: Logics/DumpParser
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+# 依存差分レビュー(依存の脆弱性対策の「PR 差分審査」層。三層構成は
+# .github/dependabot.yml 冒頭のコメントを参照)。
+#
+# NuGet パッケージの脆弱性は NuGet Audit(restore 時)が既にビルドを止めるため、
+# 本ワークフローが主に足すのは (1) GitHub Actions 依存の脆弱性検知、(2) PR 差分として
+# 入る依存の一覧化(検出時に PR コメントへ要約を出す)。情報源はリポジトリの
+# dependency graph(Dependabot アラートの前提として有効化済み)。
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # comment-summary-in-pr が PR コメントを書くために必要
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v5
+        with:
+          comment-summary-in-pr: on-failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,15 @@ Open DUMP Viewer for Oracle database/
 │  ├─ ChineseSimplified.isl               # 中国語（簡体字）翻訳（CI で自動DL）
 │  ├─ WizardImage.bmp                     # バナー画像（CI で自動生成）
 │  └─ WizardSmallImage.bmp               # 小バナー画像（CI で自動生成）
-├─ .github/workflows/
-│  ├─ build-and-release.yml                # CI/CD 正式版（release ブランチ）
-│  └─ build-and-release-beta.yml           # CI/CD ベータ版（beta ブランチ）
+├─ .github/
+│  ├─ dependabot.yml                       # 依存の継続監視（NuGet / GitHub Actions）
+│  ├─ PULL_REQUEST_TEMPLATE.md             # PR テンプレート
+│  ├─ ISSUE_TEMPLATE/                      # Issue テンプレート（バグ報告・機能要望）
+│  └─ workflows/
+│     ├─ build-and-release.yml             # CI/CD 正式版（release ブランチ）
+│     ├─ build-and-release-beta.yml        # CI/CD ベータ版（beta ブランチ）
+│     ├─ codeql.yml                        # 静的解析（C ネイティブ + Actions・週次）
+│     └─ dependency-review.yml             # PR 差分の依存審査
 ├─ README.md                               # プロジェクト説明
 ├─ CHANGELOG.md                            # リリースノート
 ├─ CLA.md                                  # コントリビューターライセンス同意書
@@ -205,6 +211,31 @@ git push origin main:release
 | Winget ID | `OpenDumpViewer.OpenDumpViewer` | `OpenDumpViewer.OpenDumpViewer.BETA` |
 
 同一 PC に両方インストール可能。
+
+## Security Automation
+
+依存とコードの脆弱性を**三層**で検知する。
+
+| 層 | 仕組み | 対象 | いつ効くか |
+|---|---|---|---|
+| 1. NuGet Audit | `Open DUMP Viewer.vbproj` の `NuGetAuditMode=all` + NU1900-1904 の warning-as-error | NuGet 依存（推移的含む） | restore / build のたび |
+| 2. Dependency Review | `.github/workflows/dependency-review.yml` | PR 差分で入る依存（GitHub Actions 含む） | PR ごと |
+| 3. Dependabot | `.github/dependabot.yml` + リポジトリの脆弱性アラート / 自動セキュリティ更新 | NuGet・GitHub Actions | 週次 + CVE 公表時に随時 |
+
+コードの静的解析は `.github/workflows/codeql.yml`（push / PR / **週次 cron**）。
+
+### CodeQL の対象範囲（重要）
+
+**CodeQL は VB.NET を解析できない**（対応言語は C/C++・C#・GitHub Actions・Go・Java・Kotlin・JavaScript・Python・Ruby・Rust・Swift・TypeScript。`csharp` 解析も `.vb` は対象外。検証日 2026-07-18）。
+
+- **対象**: `Logics/DumpParser` の C 実装（`c-cpp`、build-mode `manual` で Makefile を実ビルド）、ワークフロー自身（`actions`）
+- **対象外**: `HMI/` と `Logics/` の VB.NET コード全般
+
+C を対象に含める理由は、**信頼できない .dmp ファイルを直接パースする最も攻撃面の大きい層**であり、SECURITY.md が「対象となる脆弱性」の筆頭に挙げる「.dmp ファイル解析時のバッファオーバーフロー」がまさにここで起きるため。VB.NET 側は層 1 の NuGet Audit が依存の脆弱性を担当する。
+
+### リリースワークフローの concurrency
+
+`build-and-release*.yml` は `cancel-in-progress: false`。実リリース作成と Microsoft Store 提出まで進むため、後続 push で**割り込みキャンセルしてはならない**（待たせる）。
 
 ## License & Authentication
 

--- a/Open DUMP Viewer.vbproj
+++ b/Open DUMP Viewer.vbproj
@@ -125,4 +125,22 @@
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
+  <!--
+    NuGet Audit (依存の脆弱性対策の第1層。三層構成は .github/dependabot.yml 冒頭のコメント参照)。
+
+    CodeQL は VB.NET を解析できないため、VB.NET 側で機械的に守れるのは「依存の脆弱性」の層に
+    なる。restore のたびに GitHub Advisory Database と照合し、脆弱なパッケージが入った時点で
+    ビルドを止める (警告のままだと見逃されるため warning-as-error 化する)。
+
+      NuGetAuditMode=all   : 直接依存だけでなく推移的依存も監査する
+      NuGetAuditLevel=low  : low 以上のすべての深刻度を報告する
+      NU1900-NU1904        : 監査の警告群 (1900=監査自体の失敗, 1901-1904=深刻度別の検出)
+  -->
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
## 概要

Yagura で整備した GitHub のセキュリティ自動化一式を本リポジトリへ移植する。ただし **VB.NET・C・Inno Setup という構成差があるため、そのままのコピーではなく作り直している**。

現在このリポジトリには **PR 時に走るワークフローが 1 つもない**（release / beta ブランチへの push でのみビルドが動く）。本 PR の CodeQL と Dependency Review が初の PR チェックになる。

## ⚠️ CodeQL は VB.NET を解析できない

移植にあたっての最大の制約。[CodeQL の対応言語](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/)は C/C++・C#・GitHub Actions・Go・Java・Kotlin・JavaScript・Python・Ruby・Rust・Swift・TypeScript のみで、**VB.NET は含まれず、`csharp` 解析も `.vb` を対象にしない**（検証日 2026-07-18）。

本リポジトリの VB.NET は 439KB で最大の言語だが、`HMI/` と `Logics/` の VB.NET コードは**コードスキャンの対象外**になる。この点を承知の上で、解析対象を以下に絞った:

| 言語 | 対象 | build-mode | 理由 |
|---|---|---|---|
| `c-cpp` | `Logics/DumpParser` | `manual`（Makefile を実ビルド） | **信頼できない .dmp ファイルを直接パースする最も攻撃面の大きい層**。SECURITY.md が「対象となる脆弱性」の筆頭に挙げる「.dmp ファイル解析時のバッファオーバーフロー」がまさにここで起きる |
| `actions` | ワークフロー自身 | `none` | script injection・過剰な権限の検知 |

`c-cpp` は `build-mode: none` も選べるが、マクロ展開とヘッダ解決が不完全になり検出精度が落ちるため、gcc で実ビルドする `manual` を採用した（この Makefile は外部依存のない自己完結の C11 実装で ubuntu ランナー上で完結する）。

VB.NET 側の穴埋めとして、依存の脆弱性は下記の層 1（NuGet Audit）が担当する。

## 依存の脆弱性検知（三層）

| 層 | 仕組み | 対象 | いつ効くか |
|---|---|---|---|
| 1 | **NuGet Audit**（`vbproj` に追加）`NuGetAuditMode=all` + NU1900-1904 の warning-as-error | NuGet 依存（推移的含む） | restore / build のたび |
| 2 | **Dependency Review**（新規ワークフロー） | PR 差分で入る依存（GitHub Actions 含む） | PR ごと |
| 3 | **Dependabot**（新規設定） | NuGet・GitHub Actions | 週次（月曜 JST）+ CVE 公表時に随時 |

Dependabot は minor/patch を 1 本の PR にグループ化し、major とセキュリティ更新は個別 PR にする。AGENTS.md の「すべてのランタイム・SDK・ツールは常に最新バージョンを使用する」を機械化する役割も兼ねる（現在 `actions/checkout@v6` など数世代古いものがある）。

**定期の脆弱性診断**は 2 系統: CodeQL の週次 cron（毎週月曜 05:30 JST — コード変更がなくても新規クエリを既存コードに当てる）と、Dependabot の週次スケジュール。

## テンプレート

PR / Issue（バグ報告・機能要望）を日英併記で追加。ODV 固有の作り込み:

- バグ報告に **.dmp ファイル添付時の機密データ注意**を明記（DUMP には業務データが入る）
- 導入方法の選択肢を EXE / ZIP / Microsoft Store / winget / ソースビルドに、DUMP 形式（EXPDP / EXP）の項目を追加
- PR テンプレートのチェックリストを ODV の実態に合わせた（**バージョンは 3 ファイル同時更新**、10 言語の resx、`setup.iss`、C DLL 変更時の実 .dmp 確認）
- Discussions が無効なため、誘導先は SECURITY.md（脆弱性）と odv.dev（ライセンス）

## concurrency

`build-and-release.yml` / `build-and-release-beta.yml` に追加。**`cancel-in-progress: false`** としている — これらは実リリース作成と Microsoft Store 提出まで進むため、後続 push で割り込みキャンセルすると中途半端な成果物や提出が残りうる。連続 push は待たせる。

## 検証

- `dotnet restore` クリーン — **NU1901-1904 の検出なし**（NuGet Audit を warning-as-error にしても既存ビルドは壊れない。ClosedXML / SqlClient / WebView2 / Odbc / OleDb の 5 依存に既知の脆弱性なし）
- `dotnet build -c Release` 成功・警告 0
- ⚠️ **C の Linux ビルド（CodeQL の manual build）はローカルに gcc がなく未検証**。本 PR 上の CodeQL 実行が初回の実証になる。失敗した場合は `build-mode: none` にフォールバックする

## 別途必要なリポジトリ設定

`dependabot.yml` は「定期の版追従」までしか担当しない。**CVE 公表時の緊急 PR には脆弱性アラートと自動セキュリティ更新の有効化が必要**（現在 `dependabot_security_updates` は disabled）。これは本 PR とは別に設定する。

あわせて **Private vulnerability reporting** の有効化も推奨する（現在はメール報告のみ。GitHub 上で非公開に受け付けられるようになる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)