### PR TITLE
chore(deps): NuGet パッケージを最新版へ更新

### DIFF
--- a/Open DUMP Viewer.vbproj
+++ b/Open DUMP Viewer.vbproj
@@ -114,10 +114,10 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3124.44" />
-    <PackageReference Include="System.Data.Odbc" Version="10.0.3" />
-    <PackageReference Include="System.Data.OleDb" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
+    <PackageReference Include="System.Data.Odbc" Version="10.0.10" />
+    <PackageReference Include="System.Data.OleDb" Version="10.0.10" />
   </ItemGroup>
 
   <!-- WebView2 WPF DLL の WindowsBase バージョン競合警告を抑制 (WinForms アプリのため WPF DLL は不使用) -->


### PR DESCRIPTION
## 概要

`dotnet list package --outdated` で検出された 4 件を最新安定版へ上げる。AGENTS.md の「すべてのランタイム・SDK・ツールは常に最新バージョンを使用する」に沿った版追従。

| パッケージ | 現在 | 更新後 | 種別 |
|---|---|---|---|
| Microsoft.Data.SqlClient | 6.1.4 | **7.0.2** | メジャー |
| Microsoft.Web.WebView2 | 1.0.3124.44 | 1.0.4078.44 | SDK 更新 |
| System.Data.Odbc | 10.0.3 | 10.0.10 | パッチ |
| System.Data.OleDb | 10.0.3 | 10.0.10 | パッチ |

ClosedXML 0.105.0 は既に最新のため据え置き。

**本 PR はセキュリティ修正ではない** — NuGet Audit では脆弱性は 1 件も検出されていない（#32 で導入する監査でも検出なしを確認済み）。純粋な版追従。

## SqlClient のメジャー更新について

`SqlServerExportLogic.vb`（`SqlBulkCopy` による一括挿入）と `DatabaseConnectionDialog.vb`（接続テスト）で使用している。

メジャー更新の主な懸念は**接続の既定挙動の変更**（暗号化・証明書検証）だが、`BuildSqlServerConnectionString` は以下を**明示設定**しており既定値に依存しない:

```vb
builder.TrustServerCertificate = False
builder.Encrypt = True
```

歴史的に SqlClient のメジャー更新で問題になるのはまさにこの既定値変更のため、この実装は影響を受けにくい。

> ⚠️ **ただしビルド成功は実接続の保証にならない。** マージ前に SQL Server への実接続で以下を確認してください:
> 1. 接続ダイアログの「接続テスト」ボタン（Windows 認証 / SQL Server 認証の両方）
> 2. テーブルの SQL Server エクスポート（`SqlBulkCopy` の一括挿入が通ること）

## 検証

- `dotnet restore` クリーン
- `dotnet build -c Release` 成功・警告 0
- ⚠️ SQL Server への実接続テストは未実施（手元に SQL Server 環境がないため）

## 補足: GitHub Actions の版

本 PR には含めていない。`actions/checkout@v6`、`actions/setup-dotnet@v5`、`actions/download-artifact@v7` が古いが、これらは #32 が変更するワークフローファイル内にあり、スタックした PR 同士の衝突を避けるため分離した。**#32 のマージ後に Dependabot が自動で PR を作成する**ため、そちらで対応するのが自然。

🤖 Generated with [Claude Code](https://claude.com/claude-code)