### PR TITLE
chore(cla): CLA を自己ホスト方式へ移行し、署名文書の乖離を解消する

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,77 @@
+# CLA Assistant Lite（自己ホスト型。contributor-assistant/github-action）。
+#
+# 外部ホストサービス（cla-assistant.io）から移行した。移行理由:
+#   cla-assistant.io は署名対象の文書として **Gist しか指定できない** ため、リポジトリの
+#   CLA.md とは別に必ず写しを持つ構造になる。実際にこの写しが腐り、CLA.md が
+#   「Open DUMP Viewer for Oracle database」へ改称された後も、Gist は旧名称
+#   「OraDB DUMP Viewer」のまま署名を集め続けていた（2026-07-18 に発覚）。
+#   本方式は path-to-document がリポジトリ内のファイルを直接指すため、この乖離が起きない。
+#   あわせて、署名者の情報が第三者サービスへ渡らず自リポジトリ内に留まる。
+#
+# 署名文書は リポジトリルートの CLA.md（著作権譲渡型）。
+#
+# 前提:
+#   1. **[要オーナー作業]** リポジトリ Secret `PERSONAL_ACCESS_TOKEN` を登録する
+#      （fine-grained PAT。本リポジトリに対して Contents: Read and write /
+#      Pull requests: Read and write）。本 Action が署名台帳をコミットするために使う
+#      （既定の GITHUB_TOKEN では別ブランチへの書き込み・再チェックが安定しないため
+#      専用 PAT を要求する仕様）。**未登録だと本 Action は失敗する。**
+#   2. [済] 署名台帳の保存先ブランチ `cla-signatures`（orphan）を作成済み（2026-07-18）
+#   3. **[要オーナー作業]** cla-assistant.io 側の連携を解除する（二重に CLA チェックが
+#      走るのを避けるため）
+#
+# バージョン固定（供給網統治）: 可変タグではなくコミット SHA で固定する。
+# Vendored: contributor-assistant/github-action v2.6.1
+# (commit ca4a40a7d1004f18d9960b404b97e5f30a505a08, verified GitHub API = v2.6.1 が最新, 2026-07-18)
+
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: CLA Assistant
+        # 署名/再チェックのコメント、または PR イベントのときのみ実行する。
+        if: >-
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # オーナーが登録する専用 PAT（前提 1）。未登録だと本 Action は失敗する。
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          # 署名文書。リポジトリ内のファイルを直接指すため写しを持たない。
+          path-to-document: 'https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/CLA.md'
+          # 署名台帳の保存先（前提 2 の専用ブランチ）。
+          path-to-signatures: 'signatures/version1/cla.json'
+          branch: 'cla-signatures'
+          # 署名を要求しない主体（オーナー本人・各種 bot）。
+          allowlist: 'Yanai-Taketo,dependabot[bot],github-actions[bot]'
+          # 署名の定型文（CLA.md の記載と一致させる）。
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: >-
+            この Pull Request をマージするには、コントリビューターライセンス同意書（CLA）への署名が必要です。
+            [CLA 文書](https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/CLA.md)を読み、
+            未署名の方は以下の定型文を**この PR にコメント**してください。
+            / To merge this Pull Request, you need to sign the
+            [Contributor License Agreement](https://github.com/Open-DUMP-Viewer/Open-DUMP-Viewer/blob/main/CLA.md).
+            Please read it and post the following statement as a comment on this PR:
+          custom-allsigned-prcomment: >-
+            すべてのコントリビューターが CLA に署名済みです。ありがとうございます。
+            / All contributors have signed the CLA. Thank you.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,24 @@ git push origin main:release
 
 同一 PC に両方インストール可能。
 
+## CLA（コントリビューターライセンス同意書）
+
+署名は **CLA Assistant Lite**（`.github/workflows/cla.yml`。自己ホスト型の GitHub Action）で受け付ける。
+
+- **署名文書**: リポジトリルートの `CLA.md`（著作権譲渡型）。Action が直接この URL を参照する
+- **署名方法**: PR に `I have read the CLA Document and I hereby sign the CLA` とコメント
+- **署名台帳**: `cla-signatures` ブランチ（orphan）の `signatures/version1/cla.json`。第三者サービスへは送信しない
+- **除外**: `Yanai-Taketo` / `dependabot[bot]` / `github-actions[bot]`
+- **再チェック**: PR に `recheck` とコメント
+
+### なぜ自己ホストなのか（cla-assistant.io から移行した理由）
+
+cla-assistant.io は署名対象の文書として **Gist しか指定できない**。そのためリポジトリの `CLA.md` とは別に必ず写しを持つ構造になり、実際にその写しが腐った——`CLA.md` を Oracle 商標対応で「Open DUMP Viewer for Oracle database」へ改称した後も、**Gist は旧名称「OraDB DUMP Viewer」のまま署名を集め続けていた**（2026-07-18 に発覚。外部署名者ゼロのため実害はなし）。
+
+自己ホスト方式は `path-to-document` がリポジトリ内のファイルを直接指すため、この乖離が構造的に起きない。あわせて署名者の情報が第三者サービスへ渡らず、記録が自分の管理下に残る。
+
+**`CLA.md` を改訂したら、それがそのまま署名対象になる**（同期作業は不要）。
+
 ## Security Automation
 
 依存とコードの脆弱性を**三層**で検知する。

--- a/CLA.md
+++ b/CLA.md
@@ -58,8 +58,12 @@ Pull Request を提出することにより、以下のすべての条項に同�
 
 ## 署名方法
 
-Pull Request を提出すると、CLA Assistant が自動的に署名を求めます。
-PR のコメント欄で指示に従い、CLA に署名してください。
+Pull Request を提出すると、CLA Assistant Lite（自己ホスト型の GitHub Action）が自動的に署名を求めます。
+本同意書を読んだうえで、以下の定型文を**その Pull Request にコメント**してください。
 
-署名は GitHub アカウントに紐づけて記録されます。
+> **I have read the CLA Document and I hereby sign the CLA**
+
+署名（GitHub ユーザー名）は、本リポジトリの `cla-signatures` ブランチにある署名台帳
+（`signatures/version1/cla.json`）に記録されます。**第三者のホスト型サービスへは送信されません。**
+
 一度署名すれば、以降の PR では再署名は不要です。


### PR DESCRIPTION
## 概要

CLA の受付を **cla-assistant.io（外部 SaaS）から CLA Assistant Lite（自己ホスト型 GitHub Action）へ移行**します。

## 移行の理由: 署名文書が実際に腐っていた

cla-assistant.io は署名対象の文書として **Gist しか指定できません**。そのためリポジトリの `CLA.md` とは別に必ず写しを持つ構造になります。そしてその写しが腐っていました:

| | 名称 | 最終更新 |
|---|---|---|
| **Gist（実際に署名される文書）** | **OraDB DUMP Viewer** | 2026-02-26 |
| リポジトリの `CLA.md` | Open DUMP Viewer for Oracle database | 2026-04-16 |

`CLA.md` は Oracle 商標対応のリネーム（`feat!: rename ... for Oracle trademark compliance (v4.0.0)`）で更新されましたが、**Gist は追随していませんでした**。

つまり 2026-04-16 以降、CLA 第 1 条の「『プロジェクト』とは、OraDB DUMP Viewer を指します」という定義のまま署名を集めていたことになります。**商標対応で捨てたはずの旧名称が、公開 Gist に残って署名を集め続けていた**形です。

自己ホスト方式は `path-to-document` が**リポジトリ内のファイルを直接指す**ため、この乖離が構造的に起きません。`CLA.md` を改訂すれば、それがそのまま署名対象になります。あわせて署名者の情報が第三者サービスへ渡らず、記録が自分の管理下に残ります。

**外部署名者が 0 人の時点での移行**なので、過去の署名を無効化する影響はありません。

## 変更内容

- **`.github/workflows/cla.yml` を追加** — Action は可変タグではなくコミット SHA で固定（`ca4a40a7...` = v2.6.1。**v2.6.1 が最新であることを本日 GitHub API でライブ検証済み**）
- **`CLA.md` の「署名方法」を実態に合わせて更新** — 定型文のコメント方式、台帳の所在、第三者サービスへ送信しない旨。※条項本文（権利関係）は変更していません
- **`AGENTS.md`** に運用と移行理由を記録
- **allowlist に `dependabot[bot]` / `github-actions[bot]`** — cla-assistant.io では bot の除外が効かず、Dependabot PR #34-36 が CLA 待ちで滞留していました
- **署名台帳ブランチ `cla-signatures`（orphan）は作成済み**（本 PR とは別に push 済み。製品コードを含まない専用ブランチ）

## ⚠️ 要オーナー作業（これが揃うまで本 Action は失敗します）

**1. Secret `PERSONAL_ACCESS_TOKEN` の登録**

fine-grained PAT を作成し、リポジトリ Secret に登録してください。

- 対象リポジトリ: `Open-DUMP-Viewer/Open-DUMP-Viewer`
- 権限: **Contents: Read and write** / **Pull requests: Read and write**

この Action が署名台帳をコミットするために使います（既定の `GITHUB_TOKEN` では別ブランチへの書き込みと再チェックが安定しないため、専用 PAT を要求する仕様です）。現在このリポジトリの Secret は `AZURE_AD_*` / `CHOCOLATEY_API_KEY` / `STORE_SELLER_ID` / `WINGET_TOKEN` のみで、未登録です。

> 💡 PAT には有効期限があります。切れると CLA ゲートが「PR がマージできない」という分かりにくい形で落ちるため、期限をカレンダーに入れておくことをお勧めします。これは自己ホスト方式の唯一の保守コストです。

**2. cla-assistant.io 側の連携解除**

解除しないと `license/cla`（cla-assistant.io）と `CLA Assistant`（本 Action）の**両方が走ります**。旧側は旧名称の Gist を参照し続けるため、必ず解除してください。

## マージ後の確認

1. 上記 2 つのオーナー作業を完了
2. Dependabot PR（#34-36）で **CLA チェックが自動で通る**ことを確認（allowlist が効く）
3. 通らない場合は PR に `recheck` とコメント

## 補足: 残る CLA の論点

本 PR は**仕組みの移行のみ**で、条項の中身は変更していません。別途検討が必要な論点:

- 著作者人格権の不行使特約がない（日本法では人格権は譲渡できないため、譲渡型 CLA では通常セットで置く）
- 特許ライセンス条項がない
- 日本語のみ（10 言語対応の製品として）
- 「PR 提出により同意」と「CLA Assistant で署名」で同意成立時点が二重定義

これらは条文の作成が要るため、専門家の確認を挟むことをお勧めします。移行後は `CLA.md` を直せばそのまま署名対象に反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)