### PR TITLE
test(cla): PAT 疎通確認用の使い捨て PR（マージしません）

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -77,3 +77,4 @@ jobs:
           custom-allsigned-prcomment: >-
             すべてのコントリビューターが CLA に署名済みです。ありがとうございます。
             / All contributors have signed the CLA. Thank you.
+# (Throwaway change for the CLA PAT connectivity test. This PR is closed, not merged.)


### PR DESCRIPTION
## これは使い捨ての検証用 PR です。マージしません。

`PERSONAL_ACCESS_TOKEN` を使って CLA Assistant が以下を実行できるかを確認するためだけの PR です。

- **Pull requests: Read and write** → この PR への「署名してください」コメント投稿とステータス設定
- **Contents: Read and write** → `cla-signatures` ブランチへの署名台帳の書き込み

## なぜ必要か

allowlist に載っている主体（オーナー・Dependabot）では、CLA チェックが即座に通過してしまい **PAT を必要とする処理に到達しません**。そのため PAT の権限が正しいかを確認できず、**最初の外部コントリビューターが署名しようとした瞬間に初めて不備が発覚する**という状態でした。

これを避けるため、`main` の allowlist から一時的にオーナーを外し、意図的に署名フローを通します。

## 確認後の後始末

1. この PR を**マージせずクローズ**
2. `main` の allowlist を `Yanai-Taketo,dependabot[bot],github-actions[bot]` へ戻す
3. テスト署名が台帳に記録された場合はそれも除去
4. ブランチ削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)