### PR TITLE
docs(readme): コード署名と SmartScreen の文字化けについての説明を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ winget install OpenDumpViewer.OpenDumpViewer
 | `*_installer_{arch}.exe` | ショートカット・ファイル関連付け (.dmp) 付き |
 | `*_portable_{arch}.zip` | 解凍してすぐ使える。レジストリ変更なし |
 
+#### コード署名と実行時の警告について / Code signing & SmartScreen
+
+v4.3.0 以降の配布物（インストーラー EXE・ポータブル版のアプリ本体）には、開発者本人（**柳井建人** / YANAI Taketo）の Authenticode コード署名（タイムスタンプ付き）を付与しています。署名の実績が SmartScreen に蓄積されるまでの間は、警告画面が表示されることがあります。
+
+- **SmartScreen の青い警告画面では、発行元の日本語名が文字化けして見えることがあります**（例: `���縺�` のような表示）。これは Windows 側の既知の表示問題（非 ASCII の発行元名を ANSI で誤デコードする）で、署名自体の異常ではありません
+- **正確な発行元は、ファイルのプロパティ →「デジタル署名」タブ、または UAC の昇格ダイアログで確認してください**（こちらは正しく「柳井建人」と表示されます）。PowerShell の `Get-AuthenticodeSignature` でも確認できます
+- v4.2.1 以前の配布物は未署名のため、発行元が「不明」と表示されます
+
+Binaries from v4.3.0 onward are Authenticode-signed (with RFC 3161 timestamp) by the developer (柳井建人 / YANAI Taketo). Note: the SmartScreen dialog may garble the Japanese publisher name on some systems — a known Windows display issue, not a problem with the signature. Verify the publisher via the file's Digital Signatures property tab or `Get-AuthenticodeSignature`.
+
 ### Use / 使い方
 
 ```


### PR DESCRIPTION
## 概要

v4.3.0 でコード署名を導入したことに伴い、README のインストール節に「コード署名と実行時の警告について」を追加する（日英併記）。

- 署名者（柳井建人 / YANAI Taketo）と署名の概要
- **SmartScreen の警告画面で発行元の日本語名が文字化けし得る件**: Windows 側が非 ASCII の発行元名を ANSI で誤デコードする既知の表示問題。証明書は UTF8String で正しくエンコードされており（asn1parse で確認済み）、署名の異常ではない
- 正確な発行元の確認手段（プロパティ →「デジタル署名」タブ / UAC / Get-AuthenticodeSignature）への誘導
- v4.2.1 以前は未署名で「不明」表示になる旨

Yagura 側は同旨の注記を README + docs/code-signing-policy.md に反映済み（Yanai-Taketo/Yagura#412）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
