### PR TITLE
ci(beta): beta ワークフローに workflow_dispatch を追加する

### DIFF
--- a/.github/workflows/build-and-release-beta.yml
+++ b/.github/workflows/build-and-release-beta.yml
@@ -1,13 +1,23 @@
 name: Build and Release (Beta)
 
 # ───────────────────────────────────────────
-# トリガー: beta ブランチへの push 時に実行
+# トリガー:
+#   - beta ブランチへの push 時に実行
+#   - workflow_dispatch で手動実行 (beta ブランチを指定して使う)
 # 開発フロー: main (開発) → beta (ベータ公開) → release (正式公開)
+#
+# workflow_dispatch を置く理由: 本ワークフローは build ジョブが Environment
+# `release-signing` の承認ゲートを通るため、**承認前にキャンセルすると再開できない**。
+# push しか受け付けないと、beta が既に目的の commit を指している状態では「同じ
+# commit を push し直す」ことができず、再実行の手段が UI の Re-run only になる。
+# (build-and-release.yml には以前から workflow_dispatch があり、beta 側だけが
+#  欠けていた。2026-07-26 に実際にこれで詰まったため追加した。)
 # ───────────────────────────────────────────
 on:
   push:
     branches:
       - beta
+  workflow_dispatch:
 
 # GITHUB_TOKEN の既定を read-only に絞る。詳細は build-and-release.yml の同じ
 # ブロックのコメントを参照。


### PR DESCRIPTION
## 概要

`build-and-release-beta.yml` のトリガーに `workflow_dispatch` を追加する。

`build-and-release.yml` には以前から `workflow_dispatch` があり、beta 側だけが欠けていた。build ジョブが Environment `release-signing` の承認ゲートを通るため、**承認前に run をキャンセルすると再開できない**。トリガーが push だけだと、beta が既に目的の commit を指している状態では「同じ commit を push し直す」ことができず（no-op になる）、再実行の手段が UI の Re-run only に限られる。

4.3.1 のリリース作業中に実際にこれで詰まった（beta run を誤ってキャンセルした後、beta が既に目的の commit を指していたため push で再実行できなかった）。

## チェックリスト

該当なし（ワークフローのトリガー追加のみ。バージョン番号・コード・依存・UI 文言に変更なし）

## 検証

YAML をパースし、トリガーとジョブ構成を確認した。

```
triggers: ['push', 'workflow_dispatch']
jobs: ['build', 'release', 'publish-winget', 'publish-chocolatey']
top-level permissions: {'contents': 'read'}
```

`workflow_dispatch` は入力なしで追加しているため、手動実行時の挙動は beta への push とまったく同じ（ジョブの条件分岐を増やしていない）。

---
_Generated by [Claude Code](https://claude.ai/code/session_0142A8GpU38RtFGX7So2Uw2d)_